### PR TITLE
Update j64PartitionDevice.groovy

### DIFF
--- a/src/j64.AlarmServer.Web/SmartThingApps/j64PartitionDevice.groovy
+++ b/src/j64.AlarmServer.Web/SmartThingApps/j64PartitionDevice.groovy
@@ -18,6 +18,7 @@ metadata {
 		capability "Actuator"
 		capability "Refresh"
 		capability "Polling"
+		capability "Sensor"
     
         attribute "alarm", "string"
         attribute "mode", "string"


### PR DESCRIPTION
Added the Sensor capability in order to allow for other smartapps to detect the status of the "alarm" and "mode" attributes.